### PR TITLE
Removing Possum's Shit Take

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -346,12 +346,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	preloaded_reagents = list("nicotine" = 5,  "mint" = 5)
 
 /obj/item/clothing/mask/smokable/cigarette/khi
-	name = "\improper Kitsuhana Singularity cigarette"
+	name = "\improper Hippie's Delight cigarette"
 	icon_state = "khioff"
 	icon_on = "khion"
 	icon_off = "khioff"
 	type_butt = /obj/item/trash/cigbutt/khi
-	preloaded_reagents = list("mindbreaker" = 5, "serotrotium" = 5, "impedrezene" = 5, "space_drugs" = 5)
+	preloaded_reagents = list("mindbreaker" = 3, "serotrotium" = 2, "space_drugs" = 5)
 
 /obj/item/clothing/mask/smokable/cigarette/comred
 	name = "\improper ComRed light cigarette"


### PR DESCRIPTION
This changes the way that the Kitsuhana cigs interact with the player, removing the brain damage. Nerfing the serotrotium and mindbreaker to make it fit with the new theme of 'astrovan life'.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
